### PR TITLE
Bugfix: Layout shift on recently add groceries

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/fridgital/groceries/presentation/components/GroceryPreviewItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/fridgital/groceries/presentation/components/GroceryPreviewItem.kt
@@ -40,6 +40,7 @@ fun GroceryPreviewItem(
             modifier = Modifier
                 .width(100.dp)
                 .padding(4.dp)
+                .height(38.dp)
         )
     }
 }


### PR DESCRIPTION
- fixed layout shift due to different heights of title
  - added fixed height for title (maximum of two lines)